### PR TITLE
Needed to check for nil

### DIFF
--- a/Server.lua
+++ b/Server.lua
@@ -2465,7 +2465,9 @@ function LootReserve.Server:CancelRollRequest(item, winners, noHistory)
             end)
         end
 
-        LootReserve.Comm:BroadcastRequestRoll(LootReserve.Item(0), { }, self.RequestedRoll.Custom or self.RequestedRoll.RaidRoll);
+        if self.RequestedRoll and (self.RequestedRoll.Custom or self.RequestedRoll.RaidRoll) then
+            LootReserve.Comm:BroadcastRequestRoll(LootReserve.Item(0), { }, self.RequestedRoll.Custom or self.RequestedRoll.RaidRoll);
+        end
         self.RequestedRoll = nil;
         self.SaveProfile.RequestedRoll = self.RequestedRoll;
         self:UpdateReserveListRolls();


### PR DESCRIPTION
On my client this if was needed because I tested rolling without being in a group (I was solo).
So somehow self.RequestedRoll was nil.
I don't know if this is a good fix but it worked for me.