### PR TITLE
Add possibility to limit items to the hosts guild

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -25,6 +25,8 @@ LootReserve.Constants.ReserveResult = {
     FailedLimit              = 15,
     FailedLimitPartial       = 16,
     FailedUsable             = 17,
+    FailedGuild              = 18,
+    FailedGuildRank          = 19,
 };
 LootReserve.Constants.CancelReserveResult = {
     OK                = 0,
@@ -389,6 +391,8 @@ LootReserve.Constants.ReserveResultText =
     [result.FailedLimit]              = "That item has reached the limit of reserves",
     [result.FailedLimitPartial]       = "Not all of your reserves were accepted because the item reached the limit of reserves",
     [result.FailedUsable]             = "You may not reserve unusable items",
+    [result.FailedGuild]              = "That item is not reservable if you're not member of the hosts guild",
+    [result.FailedGuildRank]          = "This item is not reservable on your guildrank",
 };
 
 local result = LootReserve.Constants.CancelReserveResult;

--- a/ItemConditions.lua
+++ b/ItemConditions.lua
@@ -69,7 +69,7 @@ function LootReserve.ItemConditions:Save(itemID, server)
                 conditions.Guild = nil;
                 conditions.MinimumGuildRank = nil;
             end
-            if conditions.MinimumGuildRank and conditions.MinimumGuildRank >= 10 then
+            if conditions.MinimumGuildRank and conditions.MinimumGuildRank >= 11 then
                 conditions.MinimumGuildRank = nil;
             end
         end
@@ -444,7 +444,7 @@ function LootReserve.ItemConditions:Pack(conditions)
     end
     if conditions.OnlyGuild == true then
         text = text .. "G";
-        if conditions.MinimumGuildRank and conditions.MinimumGuildRank < 10 then
+        if conditions.MinimumGuildRank and conditions.MinimumGuildRank < 11 then
             text = text.. "R" .. conditions.MinimumGuildRank;
         end
     end

--- a/ItemConditions.lua
+++ b/ItemConditions.lua
@@ -8,6 +8,9 @@ local DefaultConditions =
     Faction   = nil,
     ClassMask = nil,
     Limit     = nil,
+    OnlyGuild = nil,
+    Guild = nil,
+    MinimumGuildRank = nil
 };
 
 function LootReserve.ItemConditions:Get(itemID, server)
@@ -60,6 +63,14 @@ function LootReserve.ItemConditions:Save(itemID, server)
             end
             if conditions.Limit and conditions.Limit <= 0 then
                 conditions.Limit = nil;
+            end
+            if  conditions.OnlyGuild == false then
+                conditions.OnlyGuild = nil;
+                conditions.Guild = nil;
+                conditions.MinimumGuildRank = nil;
+            end
+            if conditions.MinimumGuildRank and conditions.MinimumGuildRank >= 10 then
+                conditions.MinimumGuildRank = nil;
             end
         end
 
@@ -299,6 +310,20 @@ function LootReserve.ItemConditions:TestFaction(faction)
     return faction and UnitFactionGroup("player") == faction;
 end
 
+function LootReserve.ItemConditions:TestGuild(onlyGuild, server, player)
+    -- if server then check if player variable same as guild otherwise check if server is in my guild
+    if server then
+        return onlyGuild and UnitIsInMyGuild(player)
+    end
+    return onlyGuild and UnitIsInMyGuild(LootReserve.Client.SessionServer);
+end
+
+function LootReserve.ItemConditions:TestGuildRank(minimumGuildRank, player)
+    -- C_GuildInfo.GetGuildRankOrder(UnitGUID(player)) usable on infinite range
+    local guildRankTesterino = C_GuildInfo.GetGuildRankOrder(UnitGUID(player));
+    return minimumGuildRank and tonumber(guildRankTesterino) <= tonumber(minimumGuildRank);
+end
+
 function LootReserve.ItemConditions:TestLimit(limit, itemID, player, server)
     if limit <= 0 then
         -- Has no limiton the number of reserves
@@ -355,6 +380,15 @@ function LootReserve.ItemConditions:TestPlayer(player, itemID, server)
     if conditions and conditions.Limit and not self:TestLimit(conditions.Limit, itemID, player, server) then
         return false, LootReserve.Constants.ReserveResult.FailedLimit;
     end
+    if conditions and conditions.OnlyGuild then
+        if self:TestGuild(conditions.OnlyGuild, server, player) then
+            if conditions.MinimumGuildRank and not self:TestGuildRank(conditions.MinimumGuildRank, player) then
+                return false, LootReserve.Constants.ReserveResult.FailedGuildRank;
+            end
+        else
+            return false, LootReserve.Constants.ReserveResult.FailedGuild;
+        end
+    end
     return true;
 end
 
@@ -408,6 +442,12 @@ function LootReserve.ItemConditions:Pack(conditions)
     if conditions.Limit and conditions.Limit ~= 0 then
         text = text .. "L" .. conditions.Limit;
     end
+    if conditions.OnlyGuild == true then
+        text = text .. "G";
+        if conditions.MinimumGuildRank and conditions.MinimumGuildRank < 10 then
+            text = text.. "R" .. conditions.MinimumGuildRank;
+        end
+    end
     return text;
 end
 
@@ -440,6 +480,18 @@ function LootReserve.ItemConditions:Unpack(text)
                     conditions.Limit = tonumber(limit);
                 else
                     break;
+                end
+            end
+        elseif char == "G" then
+            conditions.OnlyGuild = true;
+            if text:sub(i+1, i+1) == "R" then
+                for len = 1, 10 do
+                    local rank = text:sub(i + 2, i + 1 + len);
+                    if tonumber(rank) then
+                        conditions.MinimumGuildRank = rank;
+                    else
+                        break;
+                    end
                 end
             end
         end

--- a/LootReserve.lua
+++ b/LootReserve.lua
@@ -1,4 +1,4 @@
-﻿local addon, ns = ...;
+local addon, ns = ...;
 
 LootReserve = LibStub("AceAddon-3.0"):NewAddon("LootReserve", "AceComm-3.0");
 LootReserve.Version = GetAddOnMetadata(addon, "Version");
@@ -346,6 +346,10 @@ end
 
 function LootReserve:GetNumClasses()
     return 11;
+end
+
+function LootReserve:GetNumGuildRanks() 
+    return GuildControlGetNumRanks()
 end
 
 function LootReserve:GetClassInfo(classID)

--- a/Windows/ServerLootEditWindow.lua
+++ b/Windows/ServerLootEditWindow.lua
@@ -83,6 +83,7 @@ function LootReserve.Server.LootEdit:UpdateLootList()
             frame.ConditionsFrame.ClassMask:Update();
             frame.ConditionsFrame.State:Update();
             frame.ConditionsFrame.Limit:Update();
+            frame.ConditionsFrame.OnlyGuild:Update();
             frame.ConditionsFrame.LimitNoHover:Update();
             frame.hovered = nil;
         end

--- a/Windows/ServerLootEditWindow.xml
+++ b/Windows/ServerLootEditWindow.xml
@@ -6,14 +6,14 @@
 			<KeyValue key="backdropBorderColor" value="NORMAL_FONT_COLOR" type="global" />
 			<KeyValue key="backdropBorderColorAlpha" value="0" type="number" />
 		</KeyValues>
-		<Size y="44" />
+		<Size y="66" />
 		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
 			<EdgeSize val="16" />
 			<BorderColor r="1" g="0.82" b="0" a="0" />
 		</Backdrop>
 		<Frames>
 			<Frame parentKey="ConditionsFrame">
-				<Size x="112" y="32" />
+				<Size x="112" y="60" />
 				<Anchors>
 					<Anchor point="RIGHT" x="-6" y="0" />
 				</Anchors>
@@ -21,7 +21,7 @@
 					<Button parentKey="ClassMask" inherits="UIMenuButtonStretchTemplate">
 						<Size y="20" />
 						<Anchors>
-							<Anchor point="TOPRIGHT" x="3" y="3" />
+							<Anchor point="TOPRIGHT" x="3" y="0" />
 						</Anchors>
 						<Scripts>
 							<OnLoad inherit="prepend">
@@ -95,7 +95,7 @@
 					<Button parentKey="State" inherits="UIMenuButtonStretchTemplate">
 						<Size y="20" />
 						<Anchors>
-							<Anchor point="BOTTOMRIGHT" x="3" y="-3" />
+							<Anchor point="TOPRIGHT" relativeKey="$parent.ClassMask" relativePoint="BOTTOMRIGHT"/>
 						</Anchors>
 						<Scripts>
 							<OnLoad>
@@ -269,6 +269,88 @@
 							</OnLoad>
 						</Scripts>
 					</Frame>
+					<Button parentKey="OnlyGuild" inherits="UIMenuButtonStretchTemplate">
+						<Size y="20" />
+						<Anchors>
+							<Anchor point="BOTTOMRIGHT" x="3" y="-3" />
+						</Anchors>
+						<Scripts>
+							<OnLoad inherit="prepend">
+								self.Update = function(self)
+									local itemID = self:GetParent():GetParent().Item;
+									local tokenID = LootReserve.Data:GetToken(itemID);
+									local conditions = LootReserve.ItemConditions:Get(tokenID or itemID, true);
+									if conditions and conditions.OnlyGuild then
+										local text = "";
+										if conditions.MinimumGuildRank then
+											text = "minimum rank: " .. GuildControlGetRankName(conditions.MinimumGuildRank);
+										else
+											text = "any guildmember";
+										end
+										self:SetText(text);
+										self.any = false;
+									else
+										self:SetText("|cFF808080Anyone|r");
+										self.any = true;
+									end
+									self:SetShown(self:GetParent():GetParent().hovered or not self.any);
+									self:SetWidth(10 + self.Text:GetStringWidth() + 10);
+									if self:GetParent().Update then
+										self:GetParent():Update();
+									end
+								end;
+								self:Update();
+							</OnLoad>
+							<OnClick>
+								if #LootReserve.Server.NewSessionSettings.LootCategories ~= 1 then
+									LootReserve:ShowError("Cannot edit Loot List while multiple raids are selected.|n|nCombined raids inherit their Loot List from each selected raid.|n|nTo modify loot for combined raids, select and edit each raid individually before combining.");
+									return;
+								end
+								local itemID = self:GetParent():GetParent().Item;
+								local tokenID = LootReserve.Data:GetToken(itemID);
+								local conditions = LootReserve.ItemConditions:Get(tokenID or itemID, true);
+								local menu =
+								{
+									LootReserve:MakeMenuSeparator(),
+									{ text = "Close" },
+								};
+								local index = 0;
+								for i = 1, LootReserve:GetNumGuildRanks() do
+									local name = GuildControlGetRankName(i);
+									if name then
+										index = index + 1;
+										table.insert(menu, index,
+										{
+											text = name,
+											checked = conditions and conditions.MinimumGuildRank and conditions.MinimumGuildRank == i or false,
+											arg1 = i,
+											func = function(_, i, _, checked)
+												if checked then
+												 	local conditions = LootReserve.ItemConditions:Make(tokenID or itemID, true);
+													conditions.MinimumGuildRank = i;
+													conditions.OnlyGuild = true;
+												 	LootReserve.ItemConditions:Save(tokenID or itemID, true);
+												else
+													local conditions = LootReserve.ItemConditions:Make(tokenID or itemID, true);
+												 	conditions.MinimumGuildRank = nil;
+													conditions.OnlyGuild = false;
+													LootReserve.ItemConditions:Save(tokenID or itemID, true);
+												end
+												CloseDropDownMenus();
+											end
+										});
+									end
+								end
+								LootReserve:OpenMenu(menu, self:GetParent().GuildRankMenu, self);
+							</OnClick>
+						</Scripts>
+					</Button>
+					<Frame parentKey="GuildRankMenu" inherits="UIDropDownMenuTemplate" hidden="true">
+						<KeyValues>
+							<KeyValue key="point" type="string" value="TOPRIGHT" />
+							<KeyValue key="relativePoint" type="string" value="BOTTOMRIGHT" />
+						</KeyValues>
+					</Frame>
 					<Frame parentKey="LimitNoHover">
 						<Size y="20" />
 						<Anchors>
@@ -339,6 +421,7 @@
 			<OnUpdate>
 				local hovered = self:IsMouseOver() and self:GetParent():GetParent():IsMouseOver() and not UIDROPDOWNMENU_OPEN_MENU and not LootReserve.Server.LootEdit.FocusedEditBox
 				                or UIDROPDOWNMENU_OPEN_MENU == self.ConditionsFrame.ClassMaskMenu
+								or UIDROPDOWNMENU_OPEN_MENU == self.ConditionsFrame.GuildRankMenu
 				                or self.ConditionsFrame.Limit.EditBox:HasFocus();
 				if self.hovered ~= hovered then
 					self.hovered = hovered;
@@ -349,6 +432,8 @@
 					self.ConditionsFrame.State:SetEnabled(hovered and not self.ConditionsFrame.State.disabled);
 					self.ConditionsFrame.State:SetShown(hovered or self.ConditionsFrame.State.shown);
 					self.ConditionsFrame.Limit:SetShown(hovered and self.ConditionsFrame.Limit.shown and not self.ConditionsFrame.State.disabled);
+					self.ConditionsFrame.OnlyGuild:SetEnabled(hovered);
+					self.ConditionsFrame.OnlyGuild:SetShown(hovered or not self.ConditionsFrame.OnlyGuild.any);
 					self.ConditionsFrame.LimitNoHover:SetShown(not hovered and self.ConditionsFrame.LimitNoHover.shown and not self.ConditionsFrame.State.disabled);
 					self.ConditionsFrame:Update();
 					for _, part in ipairs(self.ConditionBackgrounds) do


### PR DESCRIPTION
Add possibility of limiting loot to be just accessible by players in the guild of the host.
- New dropdown in loot edit window
- new client and serverside Test if item can be reserved